### PR TITLE
Define at compile time for using it in macro

### DIFF
--- a/grails.el
+++ b/grails.el
@@ -78,11 +78,12 @@
 
 ;;; Code:
 
-(defvar grails-dir-name-by-type
-  '((controller "controllers")
-    (domain "domain")
-    (service "services")
-    (view "views")))
+(eval-and-compile
+  (defvar grails-dir-name-by-type
+    '((controller "controllers")
+      (domain "domain")
+      (service "services")
+      (view "views"))))
 
 (defvar grails-postfix-by-type
   '((controller "Controller.groovy")


### PR DESCRIPTION
I got byte-compile error as below. Global variables which are referenced in macro should be declared at compile time.

```
grails.el:288:1:Error: Symbol's value as variable is void: grails-dir-name-by-type
```
